### PR TITLE
DPV-728: nrf: uart: don't drive TX pin high on init

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -989,10 +989,12 @@ static int uart_nrfx_init(const struct device *dev)
 
 	nrf_uart_disable(uart0_addr);
 
+#ifndef NRF_UART_NO_TX_IDLE_DRIVE
 	/* Setting default height state of the TX PIN to avoid glitches
 	 * on the line during peripheral activation/deactivation.
 	 */
 	nrf_gpio_pin_write(TX_PIN, 1);
+#endif
 	nrf_gpio_cfg_output(TX_PIN);
 
 	if (RX_PIN_USED) {
@@ -1109,7 +1111,9 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 	}
 
 	if (enable) {
+#ifndef NRF_UART_NO_TX_IDLE_DRIVE
 		nrf_gpio_pin_write(TX_PIN, 1);
+#endif
 		nrf_gpio_cfg_output(TX_PIN);
 		if (RX_PIN_USED) {
 			nrf_gpio_cfg_input(RX_PIN,


### PR DESCRIPTION
Driving the TX pin high during pin-initialization for the UART seems has a nasty side-effect of backpowering the reciever side. This seems to be sometimes causing incorrect behavior at boot resulting in a dead device until it gets reset by an operator.
While we mostly care for the initialization step, let's be consistent and not drive the TX pin high when configuring the GPIOs to be used.

This is OK for our case, since the reciever side includes pull-up resistors on its RX line (the NRF TX), hence preventing the pin from floating.